### PR TITLE
Auto update status on status() request

### DIFF
--- a/index.js
+++ b/index.js
@@ -175,7 +175,6 @@ class vehicle {
      */
     requestStatusRefreshSync() {
         return new Promise(async (resolve, reject) => {
-            var maxRefreshTrials = 20
             var commandId = await this.requestStatusRefresh()
             fordHeaders.set('auth-token', this.token)
             var options = {

--- a/index.js
+++ b/index.js
@@ -8,8 +8,8 @@ request.defaults.validateStatus = function () { return true; };
 
 const { fordHeaders, iamHeaders} = require('./fordHeaders')
 
-const fordAPIUrl = 'https://usapi.cv.ford.com/'
-const authUrl = 'https://fcis.ice.ibmcloud.com/'
+const fordAPIUrl = 'https://usapi.cv.ford.com'
+const authUrl = 'https://fcis.ice.ibmcloud.com'
 
 class vehicle {
     constructor(username, password, vin) {
@@ -31,7 +31,7 @@ class vehicle {
             var options = {
                 method: 'POST',
                 baseURL: authUrl,
-                url: 'v1.0/endpoint/default/token',
+                url: '/v1.0/endpoint/default/token',
                 headers: Object.fromEntries(iamHeaders),
                 data: qs.stringify(Object.fromEntries(requestData))
             }
@@ -87,16 +87,16 @@ class vehicle {
             var url = ""
             if (command == 'start') {
                 method = 'PUT'
-                url = `api/vehicles/v2/${this.vin}/engine/start`
+                url = `/api/vehicles/v2/${this.vin}/engine/start`
             } else if (command == 'stop') {
                 method = 'DELETE'
-                url = `api/vehicles/v2/${this.vin}/engine/start`
+                url = `/api/vehicles/v2/${this.vin}/engine/start`
             } else if (command == 'lock') {
                 method = 'PUT'
-                url = `api/vehicles/v2/${this.vin}/doors/lock`
+                url = `/api/vehicles/v2/${this.vin}/doors/lock`
             } else if (command == 'unlock') {
                 method = 'DELETE'
-                url = `api/vehicles/v2/${this.vin}/doors/lock`
+                url = `/api/vehicles/v2/${this.vin}/doors/lock`
             } else {
                 reject('No command specified for issueCommand!')
             }
@@ -126,9 +126,9 @@ class vehicle {
         return new Promise(async (resolve, reject) => {
             var url = ""
             if (command == 'start' || command == 'stop') {
-                url = `api/vehicles/v2/${this.vin}/engine/start/${commandId}`
+                url = `/api/vehicles/v2/${this.vin}/engine/start/${commandId}`
             } else if (command == 'lock' || command == 'unlock') {
-                url = `api/vehicles/v2/${this.vin}/doors/lock/${commandId}`
+                url = `/api/vehicles/v2/${this.vin}/doors/lock/${commandId}`
             } else {
                 reject('no command specified for commandStatus')
             }

--- a/index.js
+++ b/index.js
@@ -142,13 +142,43 @@ class vehicle {
                 var result = await request(options)
             } catch (err) {
                 console.log(err)
+                return reject(err.result.status)
+            }
+
+            if (result.status == 200) {
+                return resolve(result.data.status)
+            } else {
+                return reject(result.status)
+            }
+        })
+    }
+
+    /**
+     * Requests the Ford API to contact the vehicle for updated status data
+     * Does not wait until the refreshed status data is available! Use requestStatusRefreshSync for that.
+     * @returns commandId to track the request
+     */
+    requestStatusRefresh() {
+        return new Promise(async (resolve, reject) => {
+            fordHeaders.set('auth-token', this.token)
+            var options = {
+                method: 'PUT',
+                baseURL: fordAPIUrl,
+                url: `/api/vehicles/v2/${this.vin}/status`,
+                headers: Object.fromEntries(fordHeaders)
+            }
+
+            try {
+                var result = await request(options)
+            } catch (err) {
+                console.log(err)
                 reject(err.result.status)
             }
 
             if (result.status == 200) {
-                resolve(result.data.status)
+                return resolve(result.data.commandId)
             } else {
-                reject(result.status)
+                return reject(result.status)
             }
         })
     }

--- a/index.js
+++ b/index.js
@@ -69,13 +69,13 @@ class vehicle {
                 var result = await request(options)
             } catch (err) {
                 console.log(err)
-                reject(err.result.status)
+                return reject(err.result.status)
             }
 
             if (result.status == 200) {
                 resolve(result.data.vehiclestatus)
             } else {
-                reject(result.status)
+                return reject(result.status)
             }
         })
     }
@@ -98,7 +98,7 @@ class vehicle {
                 method = 'DELETE'
                 url = `/api/vehicles/v2/${this.vin}/doors/lock`
             } else {
-                reject('No command specified for issueCommand!')
+                return reject('No command specified for issueCommand!')
             }
             var options = {
                 method: method,
@@ -111,13 +111,13 @@ class vehicle {
                 var result = await request(options)
             } catch (err) {
                 console.log(err)
-                reject(err.result.status)
+                return reject(err.result.status)
             }
 
             if (result.status == 200) {
-                resolve(result.data)
+                return resolve(result.data)
             } else {
-                reject(result.status)
+                return reject(result.status)
             }
         })
     }
@@ -130,7 +130,7 @@ class vehicle {
             } else if (command == 'lock' || command == 'unlock') {
                 url = `/api/vehicles/v2/${this.vin}/doors/lock/${commandId}`
             } else {
-                reject('no command specified for commandStatus')
+                return reject('no command specified for commandStatus')
             }
             fordHeaders.set('auth-token', this.token)
             var options = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ffpass",
-  "version": "1.0.1",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffpass",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Interact with your FordPass enabled vehicle with JavaScript",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This fixes https://github.com/d4v3y0rk/ffpass/issues/11 - the `status()` method now updates the status data if it's outdated (= older than 5 minutes).

I also made the code more consistent and added some return statements in order to prevent some bugs.

If you have any feedback, let me know.