### PR TITLE
Update to use ford.com address for authentication

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ request.defaults.validateStatus = function () { return true; };
 const { fordHeaders, iamHeaders} = require('./fordHeaders')
 
 const fordAPIUrl = 'https://usapi.cv.ford.com'
-const authUrl = 'https://fcis.ice.ibmcloud.com'
+const authUrl = 'https://sso.ci.ford.com'
 
 class vehicle {
     constructor(username, password, vin) {


### PR DESCRIPTION
I would trust this a lot more if I knew the auth url was a ford.com address and not potentially your ibmcloud.com function stealing and proxying my creds :)