### PR TITLE
Adding try/catch around call to requestStatusRefreshSync

### DIFF
--- a/index.js
+++ b/index.js
@@ -214,7 +214,12 @@ class vehicle {
 
                 if (diffInSeconds > this.outdatedAfterSeconds) {
                     console.log("Updating status!")
-                    vehicleStatus = await this.requestStatusRefreshSync()
+                    try {
+                        vehicleStatus = await this.requestStatusRefreshSync()
+                    } catch (err) {
+                        console.log(err)
+                        return reject(err)
+                    }
                 }
 
                 return resolve(vehicleStatus)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ffpass",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ffpass",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.21.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffpass",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Interact with your FordPass enabled vehicle with JavaScript",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Adding a try/catch around the call to `this.requestStatusRefreshSync()` that happens in the `status()` method.

If the counter in `requestStatusRefreshSync()` exceeds `maxRefreshTrials` then the promise is rejected, and because that is not handled by the promise wrapping it up in `status()` it presents as an unhandled promise rejection in node.

This can be reproduced by setting the value of `maxRefreshTrials` to 0 and `outdatedAfterSeconds` to 1, then calling `await car.status()`.